### PR TITLE
Prevent directory traversal attack

### DIFF
--- a/wikiServer.js
+++ b/wikiServer.js
@@ -9,7 +9,7 @@ var serveIndex = require('serve-index');
 
 var app = express();
 var webDir = path.join(__dirname, 'web');
-var dbRoot = path.join(webDir, 'db');
+var dbRoot = path.join(webDir, 'db/'); //結尾必定要有 /
 
 app.use(cookieParser());
 app.use(session({secret: '@#$TYHaadfa1', resave: false, saveUninitialized: true}));
@@ -26,26 +26,18 @@ app.get("/", function(req, res) {
   res.redirect('/web/wikidown.html');
 });
 
-/*
-app.get("/db/:db/:name", function(req, res) {
-  var db = req.params.db;
-  var name = req.params.name;
-  fs.readFile(dbRoot+'/'+db+'/'+name, function(err, jtext) {
-    if (err)
-      response(res, 404, 'read fail!');
-    else
-      response(res, 200, jtext.toString());
-  });
-});
-*/
-
 app.post("/db/:db/:name", function(req, res) {
   var db = req.params.db;
   var name = req.params.name;
   var obj = req.body.obj;
   var msg = "db:"+db+" name:"+name+"\n"+obj;
   c.log(msg);
-  fs.writeFile(dbRoot+"/"+db+"/md/"+name, obj, function(err) {
+  var filename = path.join(dbRoot, db, 'md', name);
+  if (filename.indexOf(dbRoot) !== 0) { // 檢查是否穿越dbRoot 參考：https://en.wikipedia.org/wiki/Directory_traversal_attack
+    return response(res, 403, 'traversing root path forbidden!');
+  }
+
+  fs.writeFile(filename, obj, function(err) {
     if (err)
       response(res, 500, 'write fail!');
     else


### PR DESCRIPTION
`../` 在UNIX/Linux/Windows下代表上層資料夾的意思
原本路徑`AAA/BBB` 若這樣寫`AAA/BBB/../`會是連到`AAA`資料夾而不是`BBB`(因為上層)

原本只要利用透過 [Directory Traversal Attack](https://en.wikipedia.org/wiki/Directory_traversal_attack)
 `../../`穿透db資料夾對專案內甚至是系統檔做任何修改
將`../`做encode後可得`%2e%2e%2f` 讓網址符合nodejs的route 同時穿越了main資料夾

舉例：以下cURL 指令就可以竄改wikiDown整個頁面變成內容只有`123123`的文字（修改了wikidown.html原始碼，若再上一層甚至可以修改`wikiServer.js`的程式碼）

``` sh
curl --data "obj=123123" http://localhost:3000/db/main/%2e%2e%2f%2e%2e%2f%2e%2e%2fwikidown.html
```

也可以竄改所有該使用者的檔案，包括桌面上的檔案等等
若node很不幸用root權限執行，可以改的東西更多了，甚至可以動系統擋

Reference: [NodeJS filesystem security](https://docs.nodejitsu.com/articles/file-system/security/introduction)
